### PR TITLE
Gitpod hot reload fix

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,7 @@ tasks:
   - init: |
       rm ./renovate.json
       yarn install
-    command: yarn rw dev --fwd="--allowed-hosts localhost $(gp url 8910 | cut -c 9-) --client-web-socket-url=ws$(gp url 8910 | cut -c 5-)/ws"
+    command: yarn rw dev --fwd="--client-web-socket-url=ws$(gp url 8910 | cut -c 5-):443/ws"
 
 ports:
   - port: 5432

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,7 @@ tasks:
   - init: |
       rm ./renovate.json
       yarn install
-    command: yarn rw dev --fwd="--client-web-socket-url=ws$(gp url 8910 | cut -c 5-):443/ws"
+    command: yarn rw dev --fwd="--client-web-socket-url=ws$(gp url 8910 | cut -c 5-)/ws"
 
 ports:
   - port: 5432

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,7 @@ tasks:
   - init: |
       rm ./renovate.json
       yarn install
-    command: yarn redwood dev
+    command: yarn rw dev --fwd="--allowed-hosts localhost --allowed-hosts $(gp url 8910 | cut -c 9-) --client-web-socket-url=$(gp url 8910 | sed -e "s/https/wss/g")/ws"
 
 ports:
   - port: 5432

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,6 +9,7 @@ tasks:
   - init: |
       rm ./renovate.json
       yarn install
+    # Using Gitpod Local Companion? Change this to just `yarn rw dev`
     command: yarn rw dev --fwd="--client-web-socket-url=ws$(gp url 8910 | cut -c 5-)/ws"
 
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,7 @@ tasks:
   - init: |
       rm ./renovate.json
       yarn install
-    command: yarn rw dev --fwd="--allowed-hosts localhost --allowed-hosts $(gp url 8910 | cut -c 9-) --client-web-socket-url=$(gp url 8910 | sed -e "s/https/wss/g")/ws"
+    command: yarn rw dev --fwd="--allowed-hosts localhost $(gp url 8910 | cut -c 9-) --client-web-socket-url=ws$(gp url 8910 | cut -c 5-)/ws"
 
 ports:
   - port: 5432


### PR DESCRIPTION
Hot reload wasn't working when using Gitpod, unless you were using their [localhost companion](https://www.gitpod.io/blog/local-app) and accessing the interface via `localhost:8910`, rather than the workspace's URL (e.g., `https://8910-redwoodjs-redwood-xzxlx1hg055.ws-us53.gitpod.io/`).

This PR adds a few webpack configs to the `yarn rw dev` command in `gitpod.yml`, which enables hot reload to work without local companion and for both `localhost` and the workspace's URL.